### PR TITLE
Fix token transfer logic and card styling

### DIFF
--- a/components/Erc20List.tsx
+++ b/components/Erc20List.tsx
@@ -18,7 +18,7 @@ export const Erc20List: FC<ERC20ListProps> = (props) => {
 
   return (
     <div
-      className={`relative max-w-sm rounded overflow-hidden shadow-lg p-6 m-4outline outline-offset-2 text-white transform transition-transform hover:scale-105 shadow-lg shadow-zinc-500/50 blue-glassmorphism outline-zinc-50 ${
+      className={`relative max-w-sm rounded overflow-hidden shadow-lg p-6 m-4 outline outline-offset-2 text-white transform transition-transform hover:scale-105 shadow-lg shadow-zinc-500/50 blue-glassmorphism outline-zinc-50 ${
         isLoading && "card-border-animation"
       } ${
         updatedToken?.token === token &&

--- a/hooks/useSendToken.ts
+++ b/hooks/useSendToken.ts
@@ -47,8 +47,8 @@ export const useSendToken = (props: UseSendTokenProps) => {
   const { config } = usePrepareContractWrite({
     address: selectedToken?.token,
     abi: selectedToken?.abi,
-    functionName: "transferFrom",
-    args: [userAddress, addressTo, parseEther(amount)],
+    functionName: "transfer",
+    args: [addressTo, parseEther(amount)],
   });
 
   const {


### PR DESCRIPTION
## Summary
- correct token transfer function name
- fix card class typo for token list

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416f6ff96883318eaaf02453f9433c